### PR TITLE
Add `break` and `continue` keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Graphene syntax highlighting",
   "description": "Syntax highlighting for the Graphene language",
   "publisher": "antroseco",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "engines": {
     "vscode": "^1.74.0"
   },

--- a/syntaxes/graphene.tmLanguage.json
+++ b/syntaxes/graphene.tmLanguage.json
@@ -65,7 +65,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.graphene",
-					"match": "\\b(if|else|while|for|in|return|and|or)\\b"
+					"match": "\\b(if|else|while|for|in|return|and|or|break|continue)\\b"
 				},
 				{
 					"name": "keyword.control.import.graphene",


### PR DESCRIPTION
We've supported `break`/ `continue` in graphene since https://github.com/DaveDuck321/GrapheneLang/commit/ce0584255e13ece1e92f4d7ab75306b4e6b74967.
